### PR TITLE
Fix: typo in example comment

### DIFF
--- a/comparisons.rb
+++ b/comparisons.rb
@@ -17,7 +17,7 @@ number_students = 20
 string_teachers = "4"
 numberDogs = 0
 
-# EXAMPLE: print the result of the comparison: is number_seachers greater than number_students?
+# EXAMPLE: print the result of the comparison: is number_teachers greater than number_students?
 puts "Is number_teachers greater than number_students?", number_teachers > number_students
 # this should print: "Is numberTeachers greater than numberStudents?" false
 


### PR DESCRIPTION
Fix variable name typo on line 20 of the comparisons.rb file